### PR TITLE
Update updatable_aead.go

### DIFF
--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -133,7 +133,7 @@ func (a *updatableAEAD) SetReadKey(suite *cipherSuite, trafficSecret []byte) {
 
 // SetWriteKey sets the write key.
 // For the client, this function is called after SetReadKey.
-// For the server, this function is called before SetWriteKey.
+// For the server, this function is called before SetReadKey.
 func (a *updatableAEAD) SetWriteKey(suite *cipherSuite, trafficSecret []byte) {
 	a.sendAEAD = createAEAD(suite, trafficSecret, a.version)
 	a.headerEncrypter = newHeaderProtector(suite, trafficSecret, false, a.version)


### PR DESCRIPTION
fix: There is an issue with using SetReadKey instead of SetWriteKey in the SetWriteKey function annotation